### PR TITLE
split() for job and location search terms + Selenium click interception error on Easy Apply button fix

### DIFF
--- a/easy-apply.py
+++ b/easy-apply.py
@@ -169,7 +169,9 @@ def apply_to_listing(driver, listing):
     description = get_description(driver, listing)
     listing.set_description(description)
     try:
-        driver.find_element(By.CLASS_NAME, "jobs-apply-button").click()
+        time.sleep(2)
+        myButton = myDriver.find_element(By.XPATH, '//button[contains(@class, "jobs-apply-button")]/span[1]')
+        myDriver.execute_script("arguments[0].click();", myButton)
     except NoSuchElementException:
         driver.back()
         return
@@ -209,8 +211,8 @@ if __name__ == "__main__":
 
     login(driver, username, password)
 
-    for job in job_titles:
-        for location in locations:
+    for job in job_titles.split():
+        for location in locations.split():
             time.sleep(2)
             search_url = search(driver, job, location)
             try:


### PR DESCRIPTION
1) Lines 172-174 deal with the Selenium error regarding an intercepted click. It seems as though the original implementation would instead click on the asynchronous process operating the drop-down recent search menu. Use of the execute_script() function seems to circumvent that.
2) Lines 214-215 in this new commit use .split() so that job and location represent words found in job_titles and locations delimited by spaces. The original implementation saw only the first letter of job and location being used in LinkedIn's search boxes. However, this does present an issue when cities with multi-word names are targeted ("Los Angeles", "New York").

Hope that's at least a bit helpful since all of this was personally new for me, really cool program man!